### PR TITLE
Add high-level E2E test steps for Skipper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ build:
 		-ldflags "-s -w -X github.com/weaveworks/flagger/pkg/version.REVISION=$${GIT_COMMIT}" \
 		-a -installsuffix cgo -o ./bin/flagger ./cmd/flagger/*
 	docker build -t weaveworks/flagger:$(TAG) . -f Dockerfile
+	docker tag weaveworks/flagger:$(TAG) test/flagger:latest
 
 push:
 	docker tag weaveworks/flagger:$(TAG) weaveworks/flagger:$(VERSION)

--- a/test/README.md
+++ b/test/README.md
@@ -54,3 +54,19 @@ The e2e testing infrastructure is powered by CircleCI and [Kubernetes Kind](http
 * cleanup test environment [e2e-nginx-cleanup.sh](e2e-nginx-cleanup.sh)
 * install NGINX Ingress and Flagger with custom ingress annotations prefix [e2e-nginx-custom-annotations.sh](e2e-nginx-custom-annotations.sh)
 * repeat the canary and A/B testing workflow [e2e-nginx-tests.sh](e2e-nginx-tests.sh)
+
+### CircleCI e2e Skipper ingress workflow
+
+* install latest stable kubectl [e2e-kind.sh](e2e-kind.sh)
+* install Kubernetes Kind [e2e-kind.sh](e2e-kind.sh)
+* create local Kubernetes cluster with kind [e2e-kind.sh](e2e-kind.sh)
+* install Skipper ingress with Kustomize [e2e-skipper.sh](e2e-skipper.sh)
+* load Flagger image onto the local cluster [e2e-skipper.sh](e2e-skipper.sh)
+* install Flagger and Prometheus in the flagger-system namespace [e2e-skipper.sh](e2e-skipper.sh)
+* create a test namespace [e2e-skipper-tests.sh](e2e-skipper-tests.sh)
+* deploy the load tester in the test namespace [e2e-skipper-tests.sh](e2e-skipper-tests.sh)
+* deploy the demo workload (podinfo) and ingress in the test namespace [e2e-skipper-tests.sh](e2e-skipper-tests.sh)
+* test the canary initialization [e2e-skipper-tests.sh](e2e-skipper-tests.sh)
+* test the canary analysis and promotion using weighted traffic and the load testing webhook [e2e-skipper-tests.sh]e2e-skipper-tests.sh)
+* test the A/B testing analysis and promotion using header filters and pre/post rollout webhooks [e2e-skipper-tests.sh]e2e-skipper-tests.sh)
+* cleanup test environment [e2e-skipper-cleanup.sh](e2e-skipper-cleanup.sh)

--- a/test/e2e-skipper-tests.sh
+++ b/test/e2e-skipper-tests.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+
+# This script runs e2e tests for Canary initialization, analysis and promotion
+# Prerequisites: Kubernetes Kind and Skipper ingress controller
+
+set -o errexit
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+
+echo '>>> Creating test namespace'
+kubectl create namespace test
+
+echo '>>> Installing load tester'
+kubectl apply -k ${REPO_ROOT}/kustomize/tester
+kubectl -n test rollout status deployment/flagger-loadtester
+
+echo '>>> Initialising canary'
+kubectl apply -f ${REPO_ROOT}/test/e2e-workload.yaml
+kubectl apply -f ${REPO_ROOT}/test/e2e-skipper-test-ingress.yaml
+
+echo '>>> Create canary CRD'
+cat <<EOF | kubectl apply -f -
+apiVersion: flagger.app/v1beta1
+kind: Canary
+metadata:
+  name: podinfo
+  namespace: test
+spec:
+  provider: skipper
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: podinfo
+  ingressRef:
+    apiVersion: networking.k8s.io/v1beta1
+    kind: Ingress
+    name: podinfo
+  progressDeadlineSeconds: 60
+  service:
+    port: 80
+    targetPort: http
+  analysis:
+    interval: 15s
+    threshold: 5
+    maxWeight: 40
+    stepWeight: 20
+    metrics:
+    - name: request-success-rate
+      interval: 1m
+      # minimum req success rate (non 5xx responses)
+      # percentage (0-100)
+      thresholdRange:
+        min: 99
+    - name: request-duration
+      interval: 1m
+      # maximum req duration P99
+      # milliseconds
+      thresholdRange:
+        max: 500
+    webhooks:
+      - name: load-test
+        url: http://flagger-loadtester.test/
+        metadata:
+          type: cmd
+          cmd: "hey -z 2m -q 10 -c 2 -host app.example.com http://skipper.kube-system"
+EOF
+
+echo '>>> Waiting for primary to be ready'
+retries=50
+count=0
+ok=false
+until ${ok}; do
+  kubectl -n test get canary/podinfo | grep 'Initialized' && ok=true || ok=false
+  sleep 5
+  count=$(($count + 1))
+  if [[ ${count} -eq ${retries} ]]; then
+    kubectl -n flagger-system logs deployment/flagger
+    echo "No more retries left"
+    exit 1
+  fi
+done
+
+echo '✔ Canary initialization test passed'
+
+echo '>>> Triggering canary deployment'
+kubectl -n test set image deployment/podinfo podinfod=stefanprodan/podinfo:3.1.1
+
+echo '>>> Waiting for canary promotion'
+retries=50
+count=0
+ok=false
+failed=false
+until ${ok}; do
+  kubectl -n test get canary/podinfo | grep 'Failed' && failed=true || failed=false
+  if ${failed}; then
+    kubectl -n flagger-system logs deployment/flagger
+    echo "Canary failed!"
+    exit 1
+  fi
+  kubectl -n test describe deployment/podinfo-primary | grep '3.1.1' && ok=true || ok=false
+  sleep 10
+  kubectl -n flagger-system logs deployment/flagger --tail 1
+  count=$(($count + 1))
+  if [[ ${count} -eq ${retries} ]]; then
+    kubectl -n test describe deployment/podinfo
+    kubectl -n test describe deployment/podinfo-primary
+    kubectl -n flagger-system logs deployment/flagger
+    echo "No more retries left"
+    exit 1
+  fi
+done
+
+echo '>>> Waiting for canary finalization'
+retries=50
+count=0
+ok=false
+until ${ok}; do
+  kubectl -n test get canary/podinfo | grep 'Succeeded' && ok=true || ok=false
+  sleep 5
+  count=$(($count + 1))
+  if [[ ${count} -eq ${retries} ]]; then
+    kubectl -n flagger-system logs deployment/flagger
+    echo "No more retries left"
+    exit 1
+  fi
+done
+
+echo '✔ Canary promotion test passed'

--- a/test/e2e-skipper.sh
+++ b/test/e2e-skipper.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -o errexit
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+
+echo '>>> Installing Skipper Ingress'
+kustomize build test/skipper/ | kubectl apply -f -
+kubectl rollout status deployment/skipper-ingress -n kube-system
+kubectl get all --all-namespaces
+
+echo '>>> Loading Flagger image'
+kind load docker-image test/flagger:latest
+
+echo '>>> Installing Flagger'
+kubectl apply -k ${REPO_ROOT}/kustomize/kubernetes
+
+kubectl -n flagger-system set image deployment/flagger flagger=test/flagger:latest
+
+kubectl -n flagger-system rollout status deployment/flagger
+kubectl -n flagger-system rollout status deployment/flagger-prometheus

--- a/test/skipper/kustomization.yaml
+++ b/test/skipper/kustomization.yaml
@@ -16,6 +16,11 @@ patches:
         name: skipper-ingress
       spec:
         template:
+          metadata:
+            annotations:
+              prometheus.io/path: /metrics
+              prometheus.io/port: "9911"
+              prometheus.io/scrape: "true"
           spec:
             nodeSelector:
               $patch: delete
@@ -23,10 +28,9 @@ patches:
               $patch: delete
             containers:
               - name: skipper-ingress
+                image: registry.opensource.zalan.do/pathfinder/skipper:v0.11.135
+                ports:
+                  - name: metrics-port
+                    containerPort: 9911
                 resources:
-                  limits:
-                    cpu: "250m"
-                    memory: "256M"
-                  requests:
-                    cpu: "250m"
-                    memory: "256M"
+                  $patch: delete

--- a/test/skipper/kustomization.yaml
+++ b/test/skipper/kustomization.yaml
@@ -1,0 +1,32 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - https://raw.githubusercontent.com/zalando/skipper/master/docs/kubernetes/deploy/deployment/rbac.yaml
+  - https://raw.githubusercontent.com/zalando/skipper/master/docs/kubernetes/deploy/deployment/deployment.yaml
+
+patches:
+  - target:
+      kind: Deployment
+      name: skipper-ingress
+    patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: skipper-ingress
+      spec:
+        template:
+          spec:
+            nodeSelector:
+              $patch: delete
+            affinity:
+              $patch: delete
+            containers:
+              - name: skipper-ingress
+                resources:
+                  limits:
+                    cpu: "250m"
+                    memory: "256M"
+                  requests:
+                    cpu: "250m"
+                    memory: "256M"


### PR DESCRIPTION
- [x] install latest stable kubectl [e2e-kind.sh](e2e-kind.sh)
- [x] install Kubernetes Kind [e2e-kind.sh](e2e-kind.sh)
- [x] create local Kubernetes cluster with kind [e2e-kind.sh](e2e-kind.sh)
- [x] install Skipper ingress with Kustomize [e2e-skipper.sh](e2e-skipper.sh)
- [x] load Flagger image onto the local cluster [e2e-skipper.sh](e2e-skipper.sh)
- [x] install Flagger and Prometheus in the flagger-system namespace [e2e-skipper.sh](e2e-skipper.sh)
- [x] create a test namespace [e2e-skipper-tests.sh](e2e-skipper-tests.sh)
- [x] deploy the load tester in the test namespace [e2e-skipper-tests.sh](e2e-skipper-tests.sh)
- [x] deploy the demo workload (podinfo) and ingress in the test namespace [e2e-skipper-tests.sh](e2e-skipper-tests.sh)
- [x] test the canary initialization [e2e-skipper-tests.sh](e2e-skipper-tests.sh)
- [ ] test the canary analysis and promotion using weighted traffic and the load testing webhook [e2e-skipper-tests.sh]e2e-skipper-tests.sh)
- [ ] test the A/B testing analysis and promotion using header filters and pre/post rollout webhooks [e2e-skipper-tests.sh]e2e-skipper-tests.sh)
- [ ] cleanup test environment [e2e-skipper-cleanup.sh](e2e-skipper-cleanup.sh)

## Other TODOs:
- [ ] add CircleCI stage