### PR TITLE
🐛 remove portDiscovery from Canary

### DIFF
--- a/test/e2e-skipper-tests.sh
+++ b/test/e2e-skipper-tests.sh
@@ -40,7 +40,6 @@ spec:
     name: podinfo
     port: 80
     portName: http
-    portDiscovery: true
   analysis:
     interval: 15s
     threshold: 5


### PR DESCRIPTION
Currently we see an error that the podinfo-canary service is invalid because
of a duplicated port definition.

This commit adjusts the service settings like they work for nginx ingress.