### PR TITLE
metrics were not distinctive to sources

### DIFF
--- a/kustomize/skipper/kustomization.yaml
+++ b/kustomize/skipper/kustomization.yaml
@@ -42,14 +42,14 @@ patches:
                   initialDelaySeconds: 5
                 args:
                   - skipper
-                  - -default-filters-prepend=enableAccessLog()
+                  - -default-filters-prepend=enableAccessLog(4,5)
                   - -address=:9999
                   - -disable-metrics-compat
                   - -enable-connection-metrics
                   - -enable-profile
                   - -enable-ratelimits
                   - -experimental-upgrade
-                  - -histogram-metric-buckets=.0001,.00025,.0005,.00075,.001,.0025,.005,.0075,.01,.025,.05,.075,.1,.2,.3,.4,.5,.75,1,2,3,4,5,7,10,15,20,30,60,120,300,600
+                  - -histogram-metric-buckets=.01,1,10,100
                   - -kubernetes-in-cluster
                   - -kubernetes-path-mode=path-prefix
                   - -kubernetes

--- a/pkg/metrics/observers/skipper.go
+++ b/pkg/metrics/observers/skipper.go
@@ -18,8 +18,8 @@ var skipperQueries = map[string]string{
 	sum(rate(skipper_response_duration_seconds_bucket{route=~"{{ $route }}",code!~"5..",le="+Inf"}[{{ interval }}])) / 
 	sum(rate(skipper_response_duration_seconds_bucket{route=~"{{ $route }}",le="+Inf"}[{{ interval }}])) * 100`,
 	"request-duration": routePattern + `
-	sum(rate(skipper_response_duration_seconds_sum{route=~"{{ $route }}"}[{{ interval }}])) / 
-	sum(rate(skipper_response_duration_seconds_count{route=~"{{ $route }}"}[{{ interval }}])) * 1000`,
+	sum(rate(skipper_serve_route_duration_seconds_sum{route=~"{{ $route }}"}[{{ interval }}])) / 
+	sum(rate(skipper_serve_route_duration_seconds_count{route=~"{{ $route }}"}[{{ interval }}])) * 1000`,
 }
 
 // SkipperObserver Implementation for Skipper (https://github.com/zalando/skipper)

--- a/pkg/metrics/observers/skipper.go
+++ b/pkg/metrics/observers/skipper.go
@@ -11,7 +11,7 @@ import (
 	"github.com/weaveworks/flagger/pkg/metrics/providers"
 )
 
-const routePattern = `{{- $route := printf "kube(ew)?_%s__%s__.*__%s(_[0-9]+)?" namespace ingress service }}`
+const routePattern = `{{- $route := printf "kube(ew)?_%s__%s_canary__.*__%s_canary(_[0-9]+)?" namespace ingress service }}`
 
 var skipperQueries = map[string]string{
 	"request-success-rate": routePattern + `
@@ -77,9 +77,6 @@ func encodeModelForSkipper(model flaggerv1.MetricTemplateModel) flaggerv1.Metric
 	model.Namespace = nonWord.ReplaceAllString(model.Namespace, "_")
 	model.Service = nonWord.ReplaceAllString(model.Service, "_")
 	model.Target = nonWord.ReplaceAllString(model.Target, "_")
-
-	logger, _ := logger.NewLoggerWithEncoding("debug", "json")
-	logger.Debug("encodeModelForSkipper: ", model)
 
 	return model
 }

--- a/pkg/metrics/observers/skipper_test.go
+++ b/pkg/metrics/observers/skipper_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestSkipperObserver_GetRequestSuccessRate(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {
-		expected := ` sum( rate( skipper_response_duration_seconds_bucket{ namespace="skipper", route=~"kube(ew)?_skipper__skipper_ingress.*__backend(_[0-9]+)?", code!~"5..", le="+Inf" }[1m] ) ) / sum( rate( skipper_response_duration_seconds_bucket{ namespace="skipper", route=~"kube(ew)?_skipper__skipper_ingress.*__backend(_[0-9]+)?", le="+Inf" }[1m] ) ) * 100`
+		expected := ` sum(rate(skipper_response_duration_seconds_bucket{route=~"kube(ew)?_skipper__skipper_ingress_canary__.*__backend_canary(_[0-9]+)?",code!~"5..",le="+Inf"}[1m])) / sum(rate(skipper_response_duration_seconds_bucket{route=~"kube(ew)?_skipper__skipper_ingress_canary__.*__backend_canary(_[0-9]+)?",le="+Inf"}[1m])) * 100`
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			promql := r.URL.Query()["query"][0]
 			assert.Equal(t, expected, promql)
@@ -72,7 +72,7 @@ func TestSkipperObserver_GetRequestSuccessRate(t *testing.T) {
 }
 
 func TestSkipperObserver_GetRequestDuration(t *testing.T) {
-	expected := ` sum( rate( skipper_response_duration_seconds_sum{ namespace="skipper", route=~"kube(ew)?_skipper__skipper_ingress.*__backend(_[0-9]+)?" }[1m] ) ) / sum( rate( skipper_response_duration_seconds_count{ namespace="skipper", route=~"kube(ew)?_skipper__skipper_ingress.*__backend(_[0-9]+)?" }[1m] ) ) * 1000`
+	expected := ` sum(rate(skipper_response_duration_seconds_sum{route=~"kube(ew)?_skipper__skipper_ingress_canary__.*__backend_canary(_[0-9]+)?"}[1m])) / sum(rate(skipper_response_duration_seconds_count{route=~"kube(ew)?_skipper__skipper_ingress_canary__.*__backend_canary(_[0-9]+)?"}[1m])) * 1000`
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		promql := r.URL.Query()["query"][0]

--- a/pkg/metrics/observers/skipper_test.go
+++ b/pkg/metrics/observers/skipper_test.go
@@ -72,7 +72,7 @@ func TestSkipperObserver_GetRequestSuccessRate(t *testing.T) {
 }
 
 func TestSkipperObserver_GetRequestDuration(t *testing.T) {
-	expected := ` sum(rate(skipper_response_duration_seconds_sum{route=~"kube(ew)?_skipper__skipper_ingress_canary__.*__backend_canary(_[0-9]+)?"}[1m])) / sum(rate(skipper_response_duration_seconds_count{route=~"kube(ew)?_skipper__skipper_ingress_canary__.*__backend_canary(_[0-9]+)?"}[1m])) * 1000`
+	expected := ` sum(rate(skipper_serve_route_duration_seconds_sum{route=~"kube(ew)?_skipper__skipper_ingress_canary__.*__backend_canary(_[0-9]+)?"}[1m])) / sum(rate(skipper_serve_route_duration_seconds_count{route=~"kube(ew)?_skipper__skipper_ingress_canary__.*__backend_canary(_[0-9]+)?"}[1m])) * 1000`
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		promql := r.URL.Query()["query"][0]

--- a/pkg/router/skipper_test.go
+++ b/pkg/router/skipper_test.go
@@ -48,15 +48,17 @@ func TestSkipperRouter_Reconcile(t *testing.T) {
 				context.TODO(), canaryName, metav1.GetOptions{})
 			assert.NoError(err)
 			// test initialisation
-			assert.JSONEq(`{ "podinfo":  100, "podinfo-canary":  0 }`, inCanary.Annotations["zalando.org/backend-weights"])
-			assert.Equal("podinfo-canary", inCanary.Spec.Rules[0].HTTP.Paths[0].Backend.ServiceName, "backend flipped over")
-			// assert.Equal("podinfo-canary", inCanary.Spec.Rules[0].HTTP.Paths[1].Backend.ServiceName, "backend flipped over")
-			assert.Len(inCanary.Spec.Rules[0].HTTP.Paths, 1)
+			assert.JSONEq(`{ "podinfo-primary":  100, "podinfo-canary":  0 }`, inCanary.Annotations["zalando.org/backend-weights"])
+			assert.Equal("podinfo-primary", inCanary.Spec.Rules[0].HTTP.Paths[0].Backend.ServiceName, "backend flipped over")
+			assert.Equal("podinfo-canary", inCanary.Spec.Rules[0].HTTP.Paths[1].Backend.ServiceName, "backend flipped over")
+			assert.Len(inCanary.Spec.Rules[0].HTTP.Paths, 2)
 			inApex, err := router.kubeClient.NetworkingV1beta1().Ingresses("default").Get(
 				context.TODO(), mocks.ingressCanary.Spec.IngressRef.Name, metav1.GetOptions{})
 			assert.NoError(err)
 			assert.Equal(inCanary.Spec.Rules[0].HTTP.Paths[0].Backend.ServicePort,
 				inApex.Spec.Rules[0].HTTP.Paths[0].Backend.ServicePort, "canary backend not cloned")
+			assert.Equal(inCanary.Spec.Rules[0].HTTP.Paths[0].Backend.ServicePort,
+				inCanary.Spec.Rules[0].HTTP.Paths[1].Backend.ServicePort, "canary backend not cloned")
 		})
 	}
 }

--- a/pkg/router/skipper_test.go
+++ b/pkg/router/skipper_test.go
@@ -48,11 +48,15 @@ func TestSkipperRouter_Reconcile(t *testing.T) {
 				context.TODO(), canaryName, metav1.GetOptions{})
 			assert.NoError(err)
 			// test initialisation
-			assert.JSONEq(`{"podinfo-primary":100,"podinfo-canary":0}`, inCanary.Annotations["zalando.org/backend-weights"])
-			assert.Equal("podinfo-primary", inCanary.Spec.Rules[0].HTTP.Paths[0].Backend.ServiceName, "backend flipped over")
-			assert.Equal("podinfo-canary", inCanary.Spec.Rules[0].HTTP.Paths[1].Backend.ServiceName, "backend flipped over")
+			assert.JSONEq(`{ "podinfo":  100, "podinfo-canary":  0 }`, inCanary.Annotations["zalando.org/backend-weights"])
+			assert.Equal("podinfo-canary", inCanary.Spec.Rules[0].HTTP.Paths[0].Backend.ServiceName, "backend flipped over")
+			// assert.Equal("podinfo-canary", inCanary.Spec.Rules[0].HTTP.Paths[1].Backend.ServiceName, "backend flipped over")
+			assert.Len(inCanary.Spec.Rules[0].HTTP.Paths, 1)
+			inApex, err := router.kubeClient.NetworkingV1beta1().Ingresses("default").Get(
+				context.TODO(), mocks.ingressCanary.Spec.IngressRef.Name, metav1.GetOptions{})
+			assert.NoError(err)
 			assert.Equal(inCanary.Spec.Rules[0].HTTP.Paths[0].Backend.ServicePort,
-				inCanary.Spec.Rules[0].HTTP.Paths[1].Backend.ServicePort, "canary backend not cloned")
+				inApex.Spec.Rules[0].HTTP.Paths[0].Backend.ServicePort, "canary backend not cloned")
 		})
 	}
 }

--- a/pkg/router/skipper_test.go
+++ b/pkg/router/skipper_test.go
@@ -48,9 +48,9 @@ func TestSkipperRouter_Reconcile(t *testing.T) {
 				context.TODO(), canaryName, metav1.GetOptions{})
 			assert.NoError(err)
 			// test initialisation
-			assert.JSONEq(inCanary.Annotations["zalando.org/backend-weights"], `{"podinfo-primary":100,"podinfo-canary":0}`)
-			assert.Equal(inCanary.Spec.Rules[0].HTTP.Paths[0].Backend.ServiceName, "podinfo-primary", "backend flipped over")
-			assert.Equal(inCanary.Spec.Rules[0].HTTP.Paths[1].Backend.ServiceName, "podinfo-canary", "backend flipped over")
+			assert.JSONEq(`{"podinfo-primary":100,"podinfo-canary":0}`, inCanary.Annotations["zalando.org/backend-weights"])
+			assert.Equal("podinfo-primary", inCanary.Spec.Rules[0].HTTP.Paths[0].Backend.ServiceName, "backend flipped over")
+			assert.Equal("podinfo-canary", inCanary.Spec.Rules[0].HTTP.Paths[1].Backend.ServiceName, "backend flipped over")
 			assert.Equal(inCanary.Spec.Rules[0].HTTP.Paths[0].Backend.ServicePort,
 				inCanary.Spec.Rules[0].HTTP.Paths[1].Backend.ServicePort, "canary backend not cloned")
 		})
@@ -88,8 +88,8 @@ func TestSkipperRouter_GetSetRoutes(t *testing.T) {
 			inCanary, err := router.kubeClient.NetworkingV1beta1().Ingresses("default").Get(
 				context.TODO(), fmt.Sprintf("%s-canary", mocks.ingressCanary.Spec.IngressRef.Name), metav1.GetOptions{})
 			assert.NoError(err)
-			assert.JSONEq(inCanary.Annotations["zalando.org/backend-weights"],
-				fmt.Sprintf(`{"podinfo-primary": %d,"podinfo-canary": %d}`, tt.primary, tt.canary))
+			assert.JSONEq(fmt.Sprintf(`{"podinfo-primary": %d,"podinfo-canary": %d}`, tt.primary, tt.canary),
+				inCanary.Annotations["zalando.org/backend-weights"])
 			p, c, m, err = router.GetRoutes(mocks.ingressCanary)
 			assert.NoError(err)
 			assert.Equal(tt.primary, p)

--- a/test/e2e-skipper-canary.yaml
+++ b/test/e2e-skipper-canary.yaml
@@ -1,0 +1,65 @@
+apiVersion: flagger.app/v1beta1
+kind: Canary
+metadata:
+  name: podinfo
+  namespace: test
+spec:
+  provider: skipper
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: podinfo
+  ingressRef:
+    apiVersion: networking.k8s.io/v1beta1
+    kind: Ingress
+    name: podinfo-ingress
+  progressDeadlineSeconds: 120
+  service:
+    # service name (defaults to targetRef.name)
+    name: podinfo-service
+    # ClusterIP port number
+    port: 80
+    # container port name or number (optional)
+    targetPort: http
+    # port name can be http or grpc (default http)
+    # portName: http
+    # add all the other container ports
+    # to the ClusterIP services (default false)
+    # portDiscovery: false
+  analysis:
+    interval: 15s
+    threshold: 5
+    maxWeight: 100
+    stepWeight: 10
+    metrics:
+    - name: request-success-rate
+      interval: 15s
+      # minimum req success rate (non 5xx responses)
+      # percentage (0-100)
+      thresholdRange:
+        min: 99
+    - name: request-duration
+      interval: 15s
+      # maximum req duration P99
+      # milliseconds
+      thresholdRange:
+        max: 500
+    webhooks:
+      - name: gate
+        type: confirm-rollout
+        url: http://flagger-loadtester.test/gate/approve
+      - name: acceptance-test
+        type: pre-rollout
+        url: http://flagger-loadtester.test/
+        timeout: 10s
+        metadata:
+          type: bash
+          cmd: "curl -sd 'test' http://podinfo-service-canary/token | grep token"
+      - name: "load test"
+        type: rollout
+        url: http://flagger-loadtester.test/
+        timeout: 5s
+        metadata:
+          type: cmd
+          cmd: "hey -z 2m -q 10 -c 2 -host app.example.com http://skipper-ingress.kube-system"
+          logCmdOutput: "true"

--- a/test/e2e-skipper-canary.yaml
+++ b/test/e2e-skipper-canary.yaml
@@ -30,7 +30,7 @@ spec:
   analysis:
     interval: 15s
     threshold: 5
-    maxWeight: 70
+    maxWeight: 100
     stepWeight: 10
     metrics:
     - name: request-success-rate

--- a/test/e2e-skipper-canary.yaml
+++ b/test/e2e-skipper-canary.yaml
@@ -61,5 +61,5 @@ spec:
         timeout: 5s
         metadata:
           type: cmd
-          cmd: "hey -z 15s -q 10 -c 2 -host app.example.com http://skipper-ingress.kube-system"
+          cmd: "hey -z 2m -q 10 -c 2 -host app.example.com http://skipper-ingress.kube-system"
           logCmdOutput: "true"

--- a/test/e2e-skipper-canary.yaml
+++ b/test/e2e-skipper-canary.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: test
 spec:
   provider: skipper
+  progressDeadlineSeconds: 120
+  revertOnDeletion: true
   targetRef:
     apiVersion: apps/v1
     kind: Deployment
@@ -13,7 +15,6 @@ spec:
     apiVersion: networking.k8s.io/v1beta1
     kind: Ingress
     name: podinfo-ingress
-  progressDeadlineSeconds: 120
   service:
     # service name (defaults to targetRef.name)
     name: podinfo-service
@@ -29,7 +30,7 @@ spec:
   analysis:
     interval: 15s
     threshold: 5
-    maxWeight: 100
+    maxWeight: 70
     stepWeight: 10
     metrics:
     - name: request-success-rate
@@ -61,5 +62,5 @@ spec:
         timeout: 5s
         metadata:
           type: cmd
-          cmd: "hey -z 2m -q 10 -c 2 -host app.example.com http://skipper-ingress.kube-system"
+          cmd: "hey -z 10m -q 10 -c 2 -host app.example.com http://skipper-ingress.kube-system"
           logCmdOutput: "true"

--- a/test/e2e-skipper-canary.yaml
+++ b/test/e2e-skipper-canary.yaml
@@ -61,5 +61,5 @@ spec:
         timeout: 5s
         metadata:
           type: cmd
-          cmd: "hey -z 2m -q 10 -c 2 -host app.example.com http://skipper-ingress.kube-system"
+          cmd: "hey -z 15s -q 10 -c 2 -host app.example.com http://skipper-ingress.kube-system"
           logCmdOutput: "true"

--- a/test/e2e-skipper-test-ingress.yaml
+++ b/test/e2e-skipper-test-ingress.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: podinfo
+  name: podinfo-service
   namespace: test
 spec:
   ports:
@@ -15,7 +15,7 @@ spec:
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
-  name: podinfo
+  name: podinfo-ingress
   namespace: test
   labels:
     app: podinfo
@@ -27,5 +27,5 @@ spec:
       http:
         paths:
           - backend:
-              serviceName: podinfo
+              serviceName: podinfo-service
               servicePort: 80

--- a/test/e2e-skipper-tests.sh
+++ b/test/e2e-skipper-tests.sh
@@ -9,84 +9,17 @@ REPO_ROOT=$(git rev-parse --show-toplevel)
 
 echo '>>> Creating test namespace'
 kubectl create namespace test || true
-echo '>>> service canary'
-kubectl apply -f ${REPO_ROOT}/test/e2e-skipper-test-ingress.yaml
-echo '>>> Initialising canary'
+
+echo '>>> Initialising workload'
 kubectl apply -f ${REPO_ROOT}/test/e2e-workload.yaml
+kubectl apply -f ${REPO_ROOT}/test/e2e-workload-ingress.yaml
 
 echo '>>> Installing load tester'
 kubectl apply -k ${REPO_ROOT}/kustomize/tester
 kubectl -n test rollout status deployment/flagger-loadtester
 
 echo '>>> Create canary CRD'
-cat <<EOF | kubectl apply -f -
-apiVersion: flagger.app/v1beta1
-kind: Canary
-metadata:
-  name: podinfo
-  namespace: test
-spec:
-  provider: skipper
-  targetRef:
-    apiVersion: apps/v1
-    kind: Deployment
-    name: podinfo
-  ingressRef:
-    apiVersion: networking.k8s.io/v1beta1
-    kind: Ingress
-    name: podinfo-ingress
-  progressDeadlineSeconds: 60
-  service:
-    # service name (defaults to targetRef.name)
-    name: podinfo-service
-    # ClusterIP port number
-    port: 80
-    # container port name or number (optional)
-    targetPort: 9898
-    # port name can be http or grpc (default http)
-    portName: http
-    # add all the other container ports
-    # to the ClusterIP services (default false)
-    portDiscovery: false
-  analysis:
-    interval: 15s
-    threshold: 5
-    maxWeight: 100
-    stepWeight: 10
-    metrics:
-    - name: request-success-rate
-      interval: 15s
-      # minimum req success rate (non 5xx responses)
-      # percentage (0-100)
-      thresholdRange:
-        min: 99
-    - name: request-duration
-      interval: 15s
-      # maximum req duration P99
-      # milliseconds
-      thresholdRange:
-        max: 500
-    webhooks:
-      - name: gate
-        type: confirm-rollout
-        url: http://flagger-loadtester.test/gate/approve
-      - name: acceptance-test
-        type: pre-rollout
-        url: http://flagger-loadtester.test/
-        timeout: 10s
-        metadata:
-          type: bash
-          cmd: "curl -sd 'test' http://podinfo-service-canary/token | grep token"
-      - name: "load test"
-        type: rollout
-        url: http://flagger-loadtester.test/
-        timeout: 5s
-        metadata:
-          type: cmd
-          cmd: "hey -z 2m -q 10 -c 2 -host app.example.com http://skipper-ingress.kube-system"
-          logCmdOutput: "true"
-EOF
-
+kubectl apply -f ${REPO_ROOT}/test/e2e-skipper-canary.yaml
 echo '>>> Waiting for primary to be ready'
 retries=50
 count=0

--- a/test/e2e-skipper-tests.sh
+++ b/test/e2e-skipper-tests.sh
@@ -49,19 +49,19 @@ spec:
     # to the ClusterIP services (default false)
     portDiscovery: false
   analysis:
-    interval: 5s
+    interval: 15s
     threshold: 5
     maxWeight: 100
-    stepWeight: 5
+    stepWeight: 10
     metrics:
     - name: request-success-rate
-      interval: 30s
+      interval: 15s
       # minimum req success rate (non 5xx responses)
       # percentage (0-100)
       thresholdRange:
         min: 99
     - name: request-duration
-      interval: 30s
+      interval: 15s
       # maximum req duration P99
       # milliseconds
       thresholdRange:

--- a/test/e2e-skipper-tests.sh
+++ b/test/e2e-skipper-tests.sh
@@ -34,11 +34,11 @@ spec:
   ingressRef:
     apiVersion: networking.k8s.io/v1beta1
     kind: Ingress
-    name: podinfo
+    name: podinfo-ingress
   progressDeadlineSeconds: 60
   service:
     # service name (defaults to targetRef.name)
-    name: podinfo
+    name: podinfo-service
     # ClusterIP port number
     port: 80
     # container port name or number (optional)
@@ -49,19 +49,19 @@ spec:
     # to the ClusterIP services (default false)
     portDiscovery: false
   analysis:
-    interval: 15s
+    interval: 5s
     threshold: 5
-    maxWeight: 40
-    stepWeight: 20
+    maxWeight: 100
+    stepWeight: 5
     metrics:
     - name: request-success-rate
-      interval: 1m
+      interval: 30s
       # minimum req success rate (non 5xx responses)
       # percentage (0-100)
       thresholdRange:
         min: 99
     - name: request-duration
-      interval: 1m
+      interval: 30s
       # maximum req duration P99
       # milliseconds
       thresholdRange:
@@ -76,14 +76,14 @@ spec:
         timeout: 10s
         metadata:
           type: bash
-          cmd: "curl -sd 'test' http://podinfo-canary/token | grep token"
+          cmd: "curl -sd 'test' http://podinfo-service-canary/token | grep token"
       - name: "load test"
         type: rollout
         url: http://flagger-loadtester.test/
         timeout: 5s
         metadata:
           type: cmd
-          cmd: "hey -z 10m -q 10 -c 2 -host app.example.com http://skipper-ingress.kube-system"
+          cmd: "hey -z 2m -q 10 -c 2 -host app.example.com http://skipper-ingress.kube-system"
           logCmdOutput: "true"
 EOF
 

--- a/test/e2e-workload-ingress.yaml
+++ b/test/e2e-workload-ingress.yaml
@@ -1,17 +1,3 @@
-apiVersion: v1
-kind: Service
-metadata:
-  name: podinfo-service
-  namespace: test
-spec:
-  ports:
-  - name: http
-    port: 80
-    targetPort: http
-  selector:
-    app: podinfo
-  type: ClusterIP
----
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
@@ -20,7 +6,7 @@ metadata:
   labels:
     app: podinfo
   annotations:
-    kubernetes.io/ingress.class: "skipper"
+    kubernetes.io/ingress.class: skipper
 spec:
   rules:
     - host: app.example.com

--- a/test/local/skipper.sh
+++ b/test/local/skipper.sh
@@ -3,7 +3,7 @@
 REPO_ROOT=$(git rev-parse --show-toplevel)
 cd $REPO_ROOT
 
-make test
+# make test
 make build
 docker tag weaveworks/flagger:latest test/flagger:latest
 make loadtester-build

--- a/test/local/skipper.sh
+++ b/test/local/skipper.sh
@@ -3,6 +3,7 @@
 REPO_ROOT=$(git rev-parse --show-toplevel)
 cd $REPO_ROOT
 
+make test
 make build
 docker tag weaveworks/flagger:latest test/flagger:latest
 make loadtester-build

--- a/test/local/skipper.sh
+++ b/test/local/skipper.sh
@@ -8,7 +8,7 @@ docker tag weaveworks/flagger:latest test/flagger:latest
 make loadtester-build
 (kind get clusters && kubectl delete ns/test --force) || kind create cluster --wait 5m --image kindest/node:v1.16.9
 ./test/e2e-skipper.sh
-./test/e2e-skipper-tests.sh
-
 # port forward prometheus UI to localhost:9090
-kubectl port-forward $(kubectl get pods -l=app=flagger-prometheus -o name -n flagger-system | head -n 1) 9090:9090 -n flagger-system
+kubectl port-forward $(kubectl get pods -l=app=flagger-prometheus -o name -n flagger-system | head -n 1) 9090:9090 -n flagger-system &
+
+./test/e2e-skipper-tests.sh


### PR DESCRIPTION
The metrics were mixing all requests not just those of the canary vs primary


Results:

```
{"level":"info","ts":"2020-08-14T10:07:36.357Z","caller":"controller/events.go:28","msg":"Halt podinfo.test advancement request duration 915ms > 500ms","canary":"podinfo.test"}                                                                                                                                    
{"level":"debug","ts":"2020-08-14T10:07:36.358Z","logger":"event-broadcaster","caller":"record/event.go:278","msg":"Event(v1.ObjectReference{Kind:\"Canary\", Namespace:\"test\", Name:\"podinfo\", UID:\"c1162c0e-409a-4825-9dac-a0a6c3418e72\", APIVersion:\"flagger.app/v1beta1\", ResourceVersion:\"3704\", FieldPath:\"\"}): type: 'Warning' reason: 'Synced' Halt podinfo.test advancement request duration 915ms > 500ms"}                                             
{"level":"debug","ts":"2020-08-14T10:07:51.341Z","caller":"router/skipper.go:155","msg":"GetRoutes primaryWeight: 60, canaryWeight: 40","GetRoutes":"podinfo.test"}                                                                                                                                                 
{"level":"info","ts":"2020-08-14T10:07:51.348Z","caller":"controller/events.go:28","msg":"Rolling back podinfo.test failed checks threshold reached 5","canary":"podinfo.test"}
```


![image](https://user-images.githubusercontent.com/10851289/90239171-681c5700-de27-11ea-95ee-e6750163ee9e.png)
